### PR TITLE
Add gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:testing
+
+ENV INSTALL_DIR="_install" INSTALL_PREFIX="${INSTALL_DIR}"
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y --no-install-recommends \
+        automake \
+        build-essential \
+        docbook-xml \
+        docbook-xsl \
+        pkg-config \
+        pngcrush \
+        pngnq \
+        python3 \
+        python3-libxml2 \
+        xsltproc \
+        gettext \
+        sudo \
+        git

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+---
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - name: Build the documentation and translations
+    init: |
+      mkdir _build
+      cd _build
+      ../autogen.sh --prefix=${INSTALL_PREFIX} --without-gimp
+      make


### PR DESCRIPTION
This PR adds a relatively simple gitpod configuration that allows you to open the gimp-help repository via https://gitpod.io#https://github.com/GNOME/gimp-help or https://gitpod.io#https://gitlab.gnome.org/GNOME/gimp-help and launches in a pre-configured environment with the documentation & translations being build.